### PR TITLE
adds supported runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [action.yml](action.yml) for the full documentation for this action's inputs
 
 Source code is application code that App Runner builds and deploys for you. You point App Runner to a source code repository and choose a suitable runtime. App Runner builds an image that's based on the base image of the runtime and your application code. It then starts a service that runs a container based on this image.
 
-> Note: Only NodeJS and Python based services are supported.
+> Note: Only NodeJS, Python, and Java based services are supported.
 
 Here is the sample for deploying a NodeJS based service:
 
@@ -58,7 +58,7 @@ jobs:
           source-connection-arn: ${{ secrets.AWS_CONNECTION_SOURCE_ARN }}
           repo: https://github.com/${{ github.repository }}
           branch: ${{ github.ref }}
-          runtime: NODEJS_12
+          runtime: NODEJS_14
           build-command: npm install
           start-command: npm start
           port: 18000

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'Docker image URI with tag'
     required: false
   runtime:
-    description: 'Runtime of the application, note: AppRunner only supports `NODEJS_12` and `PYTHON_3` runtime types'
+    description: 'Runtime of the application, note: AppRunner only supports the following runtime types: PYTHON_3 | NODEJS_12 | NODEJS_14 | CORRETTO_8 | CORRETTO_11'
     required: false
   build-command:
     description: "Application build command"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import { getInput, info, setFailed, setOutput } from "@actions/core";
 import { AppRunnerClient, CreateServiceCommand, ListServicesCommand, ListServicesCommandOutput, UpdateServiceCommand, DescribeServiceCommand, ImageRepositoryType } from "@aws-sdk/client-apprunner";
 import { debug } from '@actions/core';
 
-const supportedRuntime = ['NODEJS_12', 'PYTHON_3'];
+//https://docs.aws.amazon.com/apprunner/latest/api/API_CodeConfigurationValues.html
+const supportedRuntime = ['NODEJS_12', 'PYTHON_3', 'NODEJS_14', 'CORRETTO_8', 'CORRETTO_11'];
 
 const OPERATION_IN_PROGRESS = "OPERATION_IN_PROGRESS";
 const MAX_ATTEMPTS = 120;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-app-runner-deploy/issues/10

*Description of changes:*
Adds additional supported runtimes (`NODEJS_14`, `CORRETTO_8`, `CORRETTO_11`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
