### PR TITLE
Fix deploy fail if no serviceUrl is returned

### DIFF
--- a/src/action-helper-functions.ts
+++ b/src/action-helper-functions.ts
@@ -87,7 +87,7 @@ export async function validateAndExtractServiceInfo(config: IActionParams, servi
 
     const serviceUrl = service.ServiceUrl;
     if (!serviceUrl) {
-        throw new Error(`App Runner Client returned an empty ServiceUrl for ${config.serviceName}`);
+        info(`App Runner Client returned an empty ServiceUrl for ${config.serviceName}, this could happen if the deployment is of an AWS App Runner Private Service`);
     } else {
         info(`Service URL: ${serviceUrl}`);
     }

--- a/src/action-helper-functions.ts
+++ b/src/action-helper-functions.ts
@@ -85,8 +85,8 @@ export async function validateAndExtractServiceInfo(config: IActionParams, servi
         info(`Service ARN: ${serviceArn}`);
     }
 
-    const serviceUrl = service.ServiceUrl;
-    if (!serviceUrl) {
+    const serviceUrl = service.ServiceUrl ?? "";
+    if (serviceUrl === "") {
         info(`App Runner Client returned an empty ServiceUrl for ${config.serviceName}, this could happen if the deployment is of an AWS App Runner Private Service`);
     } else {
         info(`Service URL: ${serviceUrl}`);


### PR DESCRIPTION
*Issue #, if available:* #24

*Description of changes:* Now when deploying an AWS App Runner Private Service, the deploy job won't fail because no serviceUrl was returned from the AWS API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
