### PR TITLE
Support specifying an auto-scaling configuration ARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Optional `auto-scaling-config-arn` input. When specified this will be applied to new and existing services.
+
 ## [2.1.0] - 2023-02-08
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,9 @@ inputs:
   tags:
     description: 'key-value pairs to associate with the service. This input should be JSON-formatted, for example { "env": "test" }'
     required: false
+  auto-scaling-config-arn:
+    description: 'ARN of an App Runner automatic scaling configuration that you want to associate with the App Runner service'
+    required: false
 outputs:
   service-id:
     description: 'App Runner service ID'

--- a/src/action-configuration.ts
+++ b/src/action-configuration.ts
@@ -35,6 +35,7 @@ export interface ICreateOrUpdateActionParams {
     memory: number;
     environment?: Record<string, string>;
     tags: Tag[]
+    autoScalingConfigArn?: string;
 }
 
 export type IActionParams = ICreateOrUpdateActionParams;
@@ -123,6 +124,8 @@ function getCreateOrUpdateConfig(): ICreateOrUpdateActionParams {
 
     const tags = getInput('tags', { required: false })
 
+    const autoScalingConfigArn = getInput('auto-scaling-config-arn', { required: false, trimWhitespace: true });
+
     return {
         action,
         serviceName,
@@ -135,6 +138,7 @@ function getCreateOrUpdateConfig(): ICreateOrUpdateActionParams {
         sourceConfig: imageUri ? getImageConfig(imageUri) : getSourceCodeConfig(),
         environment: getEnvironmentVariables(envVarNames),
         tags: getTags(tags),
+        autoScalingConfigArn: autoScalingConfigArn,
     };
 }
 

--- a/src/client-apprunner-commands.ts
+++ b/src/client-apprunner-commands.ts
@@ -8,6 +8,7 @@ export function getCreateCommand(config: ICreateOrUpdateActionParams): CreateSer
             Cpu: `${config.cpu} vCPU`,
             Memory: `${config.memory} GB`,
         },
+        AutoScalingConfigurationArn: config.autoScalingConfigArn,
         SourceConfiguration: (config.sourceConfig.sourceType == 'image')
             ? getImageSourceConfiguration(config.port, config.sourceConfig, config.environment)
             : getCodeSourceConfiguration(config.port, config.sourceConfig, config.environment),
@@ -22,6 +23,7 @@ export function getUpdateCommand(serviceArn: string, config: ICreateOrUpdateActi
             Cpu: `${config.cpu} vCPU`,
             Memory: `${config.memory} GB`,
         },
+        AutoScalingConfigurationArn: config.autoScalingConfigArn,
         SourceConfiguration: (config.sourceConfig.sourceType == 'image')
             ? getImageSourceConfiguration(config.port, config.sourceConfig, config.environment)
             : getCodeSourceConfiguration(config.port, config.sourceConfig, config.environment),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,6 +15,7 @@ const SERVICE_NAME = "serviceName";
 const SERVICE_ARN = "serviceArn";
 const SOURCE_ARN_CONNECTION = "sourceArnConnection";
 const ACCESS_ROLE_ARN = "accessRoleArn";
+const AUTO_SCALING_CONFIG_ARN = "autoScalingConfigArn";
 const REPO = "repo";
 const PUBLIC_DOCKER_IMAGE = "public.ecr.aws/bitnami/node:latest";
 const RUNTIME = "NODEJS_16";
@@ -301,6 +302,7 @@ describe('Deploy to AppRunner', () => {
             cpu: '3',
             memory: '5',
             tags: TAGS,
+            'auto-scaling-config-arn': AUTO_SCALING_CONFIG_ARN,
         };
 
         getInputMock.mockImplementation((name) => {
@@ -325,6 +327,7 @@ describe('Deploy to AppRunner', () => {
                     Cpu: `3 vCPU`,
                     Memory: `5 GB`,
                 },
+                AutoScalingConfigurationArn: AUTO_SCALING_CONFIG_ARN,
                 SourceConfiguration: {
                     AuthenticationConfiguration: {
                         ConnectionArn: SOURCE_ARN_CONNECTION,
@@ -454,6 +457,7 @@ describe('Deploy to AppRunner', () => {
             port: PORT,
             "wait-for-service-stability": 'false',
             tags: TAGS,
+            'auto-scaling-config-arn': AUTO_SCALING_CONFIG_ARN,
         };
 
         getInputMock.mockImplementation((name) => {
@@ -489,6 +493,7 @@ describe('Deploy to AppRunner', () => {
                     Cpu: `1 vCPU`,
                     Memory: `2 GB`,
                 },
+                AutoScalingConfigurationArn: AUTO_SCALING_CONFIG_ARN,
                 SourceConfiguration: {
                     AuthenticationConfiguration: {
                         ConnectionArn: SOURCE_ARN_CONNECTION,

--- a/src/test-helpers/fake-input.ts
+++ b/src/test-helpers/fake-input.ts
@@ -18,6 +18,7 @@ export interface FakeInput {
     cpu?: string;
     memory?: string;
     tags?: string;
+    'auto-scaling-config-arn'?: string;
 }
 
 export function getFakeInput(config: FakeInput, name: string, options?: InputOptions): string {


### PR DESCRIPTION
Hi,

Thanks for this handy GitHub Action.

*Description of changes:*

This PR adds support for specifying an [auto-scaling configuration](https://docs.aws.amazon.com/apprunner/latest/dg/manage-autoscaling.html). When an auto-scaling configuration ARN is provided as an input to the GitHub action it'll be applied when a service is created or updated.

References:
- https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-apprunner/interfaces/createservicecommandinput.html#autoscalingconfigurationarn
- https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-apprunner/interfaces/updateservicecommandinput.html#autoscalingconfigurationarn

We've tried this out using our fork and it works as expected.

Please note this PR doesn't include the changes from `npm run package` to `dist/index.js` - I assume the maintainers would rather do this post-merge / pre-release to avoid merge conflicts if other PRs are being merged in too.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. **I accept**
