### PR TITLE
Ignore empty autoscaling config ARNs

### DIFF
--- a/src/action-configuration.test.ts
+++ b/src/action-configuration.test.ts
@@ -1,0 +1,26 @@
+import { expect, test, describe } from "@jest/globals";
+import { getConfig } from "./action-configuration";
+
+describe("getConfig", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      "INPUT_SERVICE": "service_name",
+      "INPUT_SOURCE-CONNECTION-ARN": "source_connection_arn",
+      "INPUT_REPO": "repo_url",
+      "INPUT_RUNTIME": "NODEJS_16",
+      "INPUT_BUILD-COMMAND": "build-command",
+      "INPUT_START-COMMAND": "start-command"
+    }
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  test("autoscaling config ARN is undefined when input is not specified/empty", () => {
+    expect(getConfig().autoScalingConfigArn).toBeUndefined();
+  })
+})

--- a/src/action-configuration.ts
+++ b/src/action-configuration.ts
@@ -1,4 +1,4 @@
-import { getInput, getMultilineInput } from "@actions/core";
+import { getInput, getMultilineInput, InputOptions } from "@actions/core";
 import { Runtime, Tag } from "@aws-sdk/client-apprunner";
 
 // supported GitHub action modes
@@ -76,6 +76,11 @@ function getInputStr(name: string, defaultValue: string): string {
     return getInput(name, { required: false, trimWhitespace: true }) || defaultValue;
 }
 
+function getOptionalInputStr(name: string, options?: InputOptions): string | undefined {
+    const value = getInput(name, { required: false, ...options })
+    return (value.length > 0) ? value : undefined
+}
+
 function getInputBool(name: string, defaultValue: boolean): boolean {
     const val = getInput(name, { required: false, trimWhitespace: true });
     if (!val) {
@@ -124,7 +129,7 @@ function getCreateOrUpdateConfig(): ICreateOrUpdateActionParams {
 
     const tags = getInput('tags', { required: false })
 
-    const autoScalingConfigArn = getInput('auto-scaling-config-arn', { required: false, trimWhitespace: true });
+    const autoScalingConfigArn = getOptionalInputStr('auto-scaling-config-arn', { trimWhitespace: true });
 
     return {
         action,


### PR DESCRIPTION
Seems like my earlier PR (#33) has broken the action for users who don't want to specify an `auto-scaling-config-arn` input. I didn't realise `@actions/core` `getInput` will return an empty string if a value isn't set, rather than undefined.

*Issue #, if available:* https://github.com/awslabs/amazon-app-runner-deploy/issues/36

*Description of changes:*

- Introduces a more specific test for `getConfig`, because exercising this through `index.test.ts` is quite involved
- Introduces a new `getOptionalInputStr` helper in action-configuration, which returns `string | undefined`

### Notes

The tests for this PR adjust the process environment to specify inputs (mimicking the environment as it would be while the action is running). This approach could also be used  in `index.test.ts` too, as a replacement for `FakeInput`. This might make the tests simpler (let me know if you'd like a contribution adopting this approach). 

Here's the [reference for GitHub Actions inputs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs) where I discovered it sets inputs as environment variables, which is what `@actions/core` [`getInput` ends up reading](https://github.com/actions/toolkit/blob/457303960f03375db6f033e214b9f90d79c3fe5c/packages/core/src/core.ts#L128):

> When you specify an input in a workflow file or use a default input value, GitHub creates an environment variable for the input with the name INPUT_<VARIABLE_NAME>. The environment variable created converts input names to uppercase letters and replaces spaces with _ characters.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. **I accept**